### PR TITLE
Exclude non-adreno 4xx firmwares

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -51,13 +51,6 @@ bin/wcnss_filter
 bin/wfdservice
 bin/xtwifi-client
 bin/xtwifi-inet-agent
-etc/firmware/a225_pfp.fw
-etc/firmware/a225_pm4.fw
-etc/firmware/a225p5_pm4.fw
-etc/firmware/a300_pfp.fw
-etc/firmware/a300_pm4.fw
-etc/firmware/a330_pfp.fw
-etc/firmware/a330_pm4.fw
 etc/firmware/a420_pfp.fw
 etc/firmware/a420_pm4.fw
 etc/firmware/alipay.b00


### PR DESCRIPTION
Those firmwares aren't loaded on a4xx GPU, there is absolutely no reason to include them.
