### PR TITLE
Enable wider dexpreopt

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -138,8 +138,8 @@ TARGET_NO_RPC := true
 # Enable dexpreopt to speed boot time
 ifeq ($(HOST_OS),linux)
   ifeq ($(call match-word-in-list,$(TARGET_BUILD_VARIANT),user),true)
-    ifeq ($(WITH_DEXPREOPT_BOOT_IMG_ONLY),)
-      WITH_DEXPREOPT_BOOT_IMG_ONLY := true
+    ifeq ($(WITH_DEXPREOPT),)
+      WITH_DEXPREOPT := true
     endif
   endif
 endif


### PR DESCRIPTION
In general there is really no reason to avoid preoptimizing all APKs, as the device will have to optimize all of that anyway. This is a really neat feature when it comes to first boot and factory resets, but also launch time, as preoptimized dex files are in general more optimized than the ones generated directly on the device.

More info: https://source.android.com/devices/tech/dalvik/configure.html#compilation_options
