### PR TITLE
overlay: Use MONOTONIC instead of BOOTTIME for sensor timestamp

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -396,4 +396,7 @@
 
     <integer name="config_buttonBrightnessSettingDefault">60</integer>
 
+    <!-- Older rotation sensors are not setting event.timestamp correctly. Setting to
+         true will use SystemClock.elapsedRealtimeNanos() to set timestamp. -->
+    <bool name="config_useSystemClockforRotationSensor">true</bool>
 </resources>


### PR DESCRIPTION
- MM is expecting time since boot, but we can't change this neither
  in kernel nor in sensor HAL source (non-existent). This is causing
  problems with rotation sensor randomly failing.
  
  Add overlay config to use the old method of getting timestamp,
  which is compatible with our sensor blobs.

Change-Id: Ie1d1c6a76b5b6ac1f8a1970fab341a996d8ba20ek
